### PR TITLE
[feat] 매칭 페이지 전환 및 매칭 관련 API 연동

### DIFF
--- a/apps/matches/serializers.py
+++ b/apps/matches/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Matching
+from .models import Matching, MatchingStatus
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
@@ -8,14 +8,17 @@ User = get_user_model()
 class UserSimpleSerializer(serializers.ModelSerializer):
     nickname = serializers.CharField(source='profile.nickname', read_only=True)
     mbti = serializers.CharField(source='profile.mbti', read_only=True)
-    
+    username = serializers.CharField(read_only=True)
+    department_name = serializers.CharField(source='profile.department.department_name', read_only=True, allow_null=True)
+    grade = serializers.IntegerField(source='profile.grade', read_only=True, allow_null=True)
+
     class Meta:
         model = User
-        fields = ['id', 'nickname', 'mbti']
+        fields = ['id', 'username', 'nickname', 'mbti', 'department_name', 'grade']
 
 
 class MatchCreateSerializer(serializers.ModelSerializer):
-    receiver = serializers.PrimaryKeyRelatedField(read_only=False, queryset=Matching._meta.get_field('receiver').remote_field.model.objects.all())
+    receiver = serializers.PrimaryKeyRelatedField(queryset=User.objects.all())
     request_message = serializers.CharField(allow_blank=True, required=False)
 
     class Meta:
@@ -25,7 +28,8 @@ class MatchCreateSerializer(serializers.ModelSerializer):
 class MatchDetailSerializer(serializers.ModelSerializer):
     sender = UserSimpleSerializer(read_only=True)
     receiver = UserSimpleSerializer(read_only=True)
+    status_label = serializers.CharField(source='get_status_display', read_only=True)
 
     class Meta:
         model = Matching
-        fields = ['id', 'sender', 'receiver', 'status', 'matched_at', 'request_message', 'refusal_message', 'created_at']
+        fields = ['id', 'sender', 'receiver', 'status', 'status_label', 'matched_at', 'request_message', 'refusal_message', 'created_at']   

--- a/apps/matches/static/matches/js/matches.js
+++ b/apps/matches/static/matches/js/matches.js
@@ -1,3 +1,62 @@
+// === Auth & HTTP helpers ===
+function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop().split(';').shift();
+  return null;
+}
+
+function getAccessToken() {
+  return (
+    localStorage.getItem('access') ||
+    localStorage.getItem('access_token') ||
+    localStorage.getItem('token') ||
+    ''
+  );
+}
+
+async function apiFetch(url, options = {}) {
+  const token = getAccessToken();
+  const headers = Object.assign(
+    {
+      'Accept': 'application/json',
+    },
+    options.headers || {}
+  );
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const method = (options.method || 'GET').toUpperCase();
+  if (method !== 'GET' && method !== 'HEAD') {
+    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+    const csrftoken = getCookie('csrftoken');
+    if (csrftoken) headers['X-CSRFToken'] = csrftoken;
+  }
+  const resp = await fetch(url, Object.assign({}, options, { headers }));
+  if (resp.status === 401) {
+    // 토큰 만료 등: 로그인 페이지로 유도
+    window.location.replace('/users/login/');
+    return Promise.reject(new Error('Unauthorized'));
+  }
+  return resp;
+}
+
+const MATCH_API_BASE = '/matches/api/matches';
+
+// === Page navigation(base.html에 있는) ===
+// TODO: 추후에 url이나 페이지가 변경되면 수정해야됨
+function setCurrentPage(name) {
+  const routes = {
+    home: '/profiles/profile/',
+    browse: '/explore/',
+    chat_list: '/chats/',
+    matching: '/matches/',
+    mypage: '/users/mypage/?format=html',
+  };
+  const url = routes[name] || '/profiles/profile/';
+  window.location.href = url;
+}
+// ensure global
+window.setCurrentPage = setCurrentPage;
+
 // 탭 전환 함수
     function showTab(tabName) {
         const tabs = document.querySelectorAll('.tab-content');
@@ -19,7 +78,42 @@
             activeButton.id = 'active';
         }
     }
- 
+
+// === Match actions (Accept/Reject) ===
+async function updateMatchStatus(matchId, nextStatus, payload = {}) {
+  if (!matchId) return;
+  try {
+    const resp = await apiFetch(`${MATCH_API_BASE}/${matchId}/status/`, {
+      method: 'PATCH',
+      body: JSON.stringify(Object.assign({ status: nextStatus }, payload)),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      alert(err.detail || '상태 변경에 실패했습니다.');
+      return;
+    }
+    // 성공 시 새로고침으로 가장 확실하게 반영
+    window.location.reload();
+  } catch (e) {
+    console.error(e);
+    alert('요청 중 오류가 발생했습니다.');
+  }
+}
+
+function extractMatchIdFrom(el) {
+  if (!el) return null;
+  // 우선순위: data-id, data-match-id, value, id 속성 내 숫자
+  return (
+    el.dataset?.id ||
+    el.dataset?.matchId ||
+    el.getAttribute('data-id') ||
+    el.getAttribute('data-match-id') ||
+    el.value ||
+    (el.id && el.id.match(/\d+/)?.[0]) ||
+    null
+  );
+}
+
 document.addEventListener("DOMContentLoaded", function () {
 
     showTab('request');
@@ -53,6 +147,8 @@ document.addEventListener("DOMContentLoaded", function () {
     // 정중히 거절하기 버튼
     document.querySelectorAll(".reject").forEach(btn => {
         btn.addEventListener("click", function () {
+            const matchId = extractMatchIdFrom(this);
+            if (rejectModal) rejectModal.dataset.currentMatchId = matchId || '';
             showModal(rejectModal);
         });
     });
@@ -61,6 +157,14 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll(".tab-right").forEach(btn => {
         btn.addEventListener("click", function () {
             showModal(reviewModal);
+        });
+    });
+
+    // 수락하기 버튼
+    document.querySelectorAll('.accept').forEach(btn => {
+        btn.addEventListener('click', function () {
+            const matchId = extractMatchIdFrom(this);
+            updateMatchStatus(matchId, 'ACCEPTED');
         });
     });
 
@@ -80,6 +184,16 @@ document.addEventListener("DOMContentLoaded", function () {
     document.getElementById("review-cancle").addEventListener("click", function () {
         hideModal(reviewModal);
     })
+
+    const rejectSubmitBtn = document.getElementById('reject-submit') || document.querySelector('[data-role="reject-submit"]');
+    const rejectReasonInput = document.getElementById('reject-text') || document.getElementById('reject-textarea') || document.querySelector('[name="reject_reason"]');
+    if (rejectSubmitBtn) {
+        rejectSubmitBtn.addEventListener('click', function () {
+            const matchId = rejectModal?.dataset?.currentMatchId;
+            const reason = (rejectReasonInput && rejectReasonInput.value) ? rejectReasonInput.value.trim() : '';
+            updateMatchStatus(matchId, 'REJECTED', reason ? { reason } : {});
+        });
+    }
 
     // 오버레이 클릭 → 모달 닫기
     overlay.addEventListener("click", function () {

--- a/apps/matches/templates/matches/base.html
+++ b/apps/matches/templates/matches/base.html
@@ -34,7 +34,7 @@
             <div class="nav-emoji">🔍</div>
             <span class="nav-label">탐색</span>
         </button>
-        <button class="nav-item" onclick="setCurrentPage('chat-list')">
+        <button class="nav-item" onclick="setCurrentPage('chat_list')">
             <div class="nav-emoji">💬</div>
             <span class="nav-label">대화</span>
         </button>

--- a/apps/matches/templates/matches/matches.html
+++ b/apps/matches/templates/matches/matches.html
@@ -57,8 +57,8 @@
             </div>
             <div class="tab-content-bottom">
                 {% if match.status == MatchingStatus.PENDING and match.receiver == user %}
-                    <button type="submit" class="accept">수락하기</button>
-                    <button type="submit" class="reject">정중히 거절하기</button>
+                    <button type="submit" class="accept" data-id="{{ match.id }}">수락하기</button>
+                    <button type="submit" class="reject" data-id="{{ match.id }}">정중히 거절하기</button>
                 {% elif match.status == MatchingStatus.PENDING and match.sender == user %}
                     <button type="submit" class="ask">📤 신청 완료</button>
                 {% endif %}
@@ -86,12 +86,15 @@
                 <input type="radio" name="reject" value="3">지금은 만남이 어려워요
             </label>
             <label>
-                <input type="radio" name="reject" value="3">다른 이유
+                <input type="radio" name="reject" value="4">다른 이유
             </label>
+        </div>
+        <div class="reject-free-text">
+            <textarea id="reject-text" rows="3" placeholder="선택: 정중한 거절 사유를 입력하세요 (예: 일정이 겹쳐요)"></textarea>
         </div>
         <div class="reject-comment">💙 정중한 거절도 상대방에 대한 배려입니다</div>
         <div class="submit-button">
-            <button type="submit" class="reject-button">
+            <button type="submit" id="reject-submit" class="reject-button">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
                     <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z"/>
                 </svg> 거절하기
@@ -102,16 +105,27 @@
 </div>
 
 <div id="tab-completed" class="tab-content">        <!--내부 텍스트는 나중에 수정 필요-->
-    {# {% for in % } #}
+    {% for match in accepted_matchings %}
     <div class="tab-container" id="completed">
         <div class="tab-left">
             <div>
-                <div class="circle-1">닉</div>
+                <div class="circle-1">
+                    {% if match.sender == user %}
+                        {{ match.receiver.username|slice:":1" }}
+                    {% else %}
+                        {{ match.sender.username|slice:":1" }}
+                    {% endif %}
+                </div>
             </div>
             <div class="content">
                 <div>
-                    <div><strong class="nickname">닉네임</strong></div>
-                    <div class="major">전공과 학년</div>
+                    {% if match.sender == user %}
+                        <div><strong class="nickname">{{ match.receiver.profile.nickname }}</strong></div>
+                        <div class="major">{{ match.receiver.profile.department.department_name }} {{ match.receiver.profile.grade }}</div>
+                    {% else %}
+                        <div><strong class="nickname">{{ match.sender.profile.nickname }}</strong></div>
+                        <div class="major">{{ match.sender.profile.department.department_name }} {{ match.sender.profile.grade }}</div>
+                    {% endif %}
                 </div>
                 <div class="matching-complete">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2" viewBox="0 0 16 16">
@@ -122,18 +136,23 @@
             </div>
         </div>
         <div class="tab-right">
-            <div>
-                ⭐ 매너온도 남기기
-            </div>
+            <div>⭐ 매너온도 남기기</div>
         </div>
     </div>
-    {# {% endfor %} #}
+    {% empty %}
+    <p>완료된 만남이 없습니다.</p>
+    {% endfor %}
+    
 
     <div class="modal-overlay" id="review-modal-overlay"></div>
     <div id="review" class="small-view">        <!--작은 창-->
         <div class="close"><span>&times;</span></div>
         <div class="small-title">⭐ 매너온도 남기기</div>
-        <div class="small-comment">창업왕철수님과의 만남은 어떠셨나요?</div>        <!--닉네임 바꿔야 함-->
+        {% if match.sender == user %}
+            <div class="small-comment">{{ match.receiver.profile.nickname }}님과의 만남은 어떠셨나요?</div>
+        {% else %}
+            <div class="small-comment">{{ match.sender.profile.nickname }}님과의 만남은 어떠셨나요?</div>
+        {% endif %}
         <div class="review-container">
             <div class="manner">
                 <div class="review-title">🌡️ 매너온도 (1-5)</div>

--- a/apps/matches/urls.py
+++ b/apps/matches/urls.py
@@ -4,9 +4,9 @@ from . import views
 app_name = 'matches'
 
 urlpatterns = [
-    path("", views.MatchListCreateView.as_view(), name="match-list-create"),  # GET, POST
-    path("<int:pk>/", views.MatchStatusUpdateView.as_view(), name="match-status-update"),  # PATCH
-    path("mine", views.MyMatchListView.as_view(), name="my-match-list"),  # GET with status query param
-    path("recommendations", views.MatchRecommendationView.as_view(), name="match-recommendations"),  # GET
-    path("list/", views.matching_list, name="matching-list"),     # 매칭 리스트 페이지
+    path("", views.matching_list, name="matching-list"),     # 매칭 리스트 페이지
+    path("api/matches/", views.MatchListCreateView.as_view(), name="match-list-create"),  # GET, POST
+    path("api/matches/<int:pk>/status/", views.MatchStatusUpdateView.as_view(), name="match-status-update"),  # PATCH
+    path("api/matches/mine/", views.MyMatchListView.as_view(), name="my-match-list"),  # GET with status query param
+    path("api/matches/recommendations/", views.MatchRecommendationView.as_view(), name="match-recommendations"),  # GET
 ]

--- a/apps/matches/views.py
+++ b/apps/matches/views.py
@@ -1,4 +1,5 @@
 from rest_framework import generics, status
+from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -14,7 +15,20 @@ from django.contrib.auth.decorators import login_required
 # 1. 매칭 목록 조회(GET) & 매칭 신청(POST)
 class MatchListCreateView(generics.ListCreateAPIView):
     permission_classes = [IsAuthenticated]
-    queryset = Matching.objects.all()
+
+    def get_queryset(self):
+        u = self.request.user
+        qs = Matching.objects.filter(
+            Q(sender=u) | Q(receiver=u)
+        ).select_related(
+            'sender__profile__department',
+            'receiver__profile__department'
+        ).order_by('-created_at')
+
+        status_filter = self.request.query_params.get('status')
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+        return qs
 
     def get_serializer_class(self):
         if self.request.method == 'POST':
@@ -22,7 +36,20 @@ class MatchListCreateView(generics.ListCreateAPIView):
         return MatchDetailSerializer
 
     def perform_create(self, serializer):
-        serializer.save(sender=self.request.user)
+        sender = self.request.user
+        receiver = serializer.validated_data.get('receiver')
+        if receiver == sender:
+            raise serializers.ValidationError({"receiver": ["본인에게는 신청할 수 없습니다."]})
+
+        # 이미 미결(PENDING) 상태의 동일 조합이 있으면 차단
+        exists_pending = Matching.objects.filter(
+            Q(sender=sender, receiver=receiver) | Q(sender=receiver, receiver=sender),
+            status=MatchingStatus.PENDING
+        ).exists()
+        if exists_pending:
+            raise serializers.ValidationError({"non_field_errors": ["이미 진행 중인 신청이 있습니다."]})
+
+        serializer.save(sender=sender)
 
 # 2. 매칭 상태 변경 (PATCH)
 class MatchStatusUpdateView(generics.UpdateAPIView):
@@ -32,7 +59,7 @@ class MatchStatusUpdateView(generics.UpdateAPIView):
 
     def perform_update(self, serializer):
         match = self.get_object()
-        if match.receiver != self.request.user:
+        if not (match.receiver == self.request.user):
             raise PermissionDenied("수락 또는 거절은 수신자만 할 수 있습니다.")
         serializer.save()
 
@@ -42,11 +69,17 @@ class MyMatchListView(generics.ListAPIView):
     serializer_class = MatchDetailSerializer
 
     def get_queryset(self):
+        u = self.request.user
+        qs = Matching.objects.filter(
+            Q(sender=u) | Q(receiver=u)
+        ).select_related(
+            'sender__profile__department',
+            'receiver__profile__department'
+        ).order_by('-created_at')
         status_filter = self.request.query_params.get('status')
-        return Matching.objects.filter(
-            (Q(sender=self.request.user) | Q(receiver=self.request.user)) &
-            Q(status=status_filter)
-        )
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+        return qs
 
 # 4. AI 추천 매칭 대상 반환 (GET)
 class MatchRecommendationView(APIView):
@@ -62,16 +95,29 @@ class MatchRecommendationView(APIView):
 def matching_list(request):
     user = request.user
 
-    matchings = Matching.objects.filter(
-        Q(sender=user) | Q(receiver=user)       # 내가 보낸 매칭이거나 내가 받은 매칭인 경우 모두 가져오는 조건
+    base_qs = Matching.objects.filter(
+        Q(sender=user) | Q(receiver=user)
     ).select_related(
         'sender__profile__department',
         'receiver__profile__department'
-    ).order_by('-created_at')       # 최신순 정렬
+    ).order_by('-created_at')
+
+    request_matchings = base_qs.filter(status=MatchingStatus.PENDING)
+    accepted_matchings = base_qs.filter(status=MatchingStatus.ACCEPTED)
+    rejected_matchings = base_qs.filter(status=MatchingStatus.REJECTED)
 
     context = {
-        'matchings': matchings,
+        # 기존 호환용
+        'matchings': base_qs,
         'MatchingStatus': MatchingStatus,
-        'user' : user,
+        'user': user,
+        # 탭별 분리 데이터
+        'request_matchings': request_matchings,
+        'accepted_matchings': accepted_matchings,
+        'rejected_matchings': rejected_matchings,
+        # 카운트 뱃지
+        'count_request': request_matchings.count(),
+        'count_accepted': accepted_matchings.count(),
+        'count_rejected': rejected_matchings.count(),
     }
     return render(request, 'matches/matches.html', context)

--- a/apps/profiles/templates/profiles/profile_home.html
+++ b/apps/profiles/templates/profiles/profile_home.html
@@ -229,8 +229,8 @@
 
           function goToMatching() {
               // 매칭 현황 페이지로 이동
-              console.log('매칭 현황 페이지로 이동 - 준비중');
-              alert('매칭 기능은 준비 중입니다!');
+              console.log('매칭 현황 페이지로 이동');
+              window.location.href = '/matches/';
           }
 
           // 하단 네비게이션 페이지 전환 함수
@@ -261,8 +261,8 @@
                     alert('채팅 기능은 준비 중입니다!');
                     break;
                 case 'matching':
-                    console.log('매칭 페이지로 이동 - 준비중');
-                    alert('매칭 기능은 준비 중입니다!');
+                    console.log('매칭 현황 페이지로 이동');
+                    window.location.href = '/matches/';
                     break;
                 case 'mypage':
                     console.log('마이페이지로 이동');

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -704,8 +704,36 @@ def user_logout(request):
     
     응답: 로그인 페이지로 리다이렉트 (/users/login/)
     """
+    # 1) 세션/서버 측 상태 정리
+    refresh_in_session = request.session.pop('refresh_token', None)
     request.session.pop('access_token', None)
-    request.session.pop('refresh_token', None)
+
+    # Django 인증 세션 로그아웃
     logout(request)
-    return redirect('/users/login/')
+
+    # 2) 클라이언트 측 로컬 상태도 제거해야 완전 로그아웃 (localStorage/쿠키)
+    #    템플릿 없이도 동작하도록 스크립트를 직접 반환 후 /users/login/ 으로 이동
+    from django.http import HttpResponse
+    script = """
+    <script>
+      try {
+        localStorage.removeItem('access');
+        localStorage.removeItem('refresh');
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        sessionStorage.clear();
+      } catch (e) {}
+      // 쿠키 제거는 서버가 지시
+      window.location.replace('/users/login/');
+    </script>
+    """
+
+    response = HttpResponse(script)
+    # 3) 관련 쿠키 제거 지시 (있을 경우)
+    for name in ['access', 'refresh', 'access_token', 'refresh_token', 'csrftoken', 'sessionid']:
+        response.delete_cookie(name)
+
+    return response
+
+
 


### PR DESCRIPTION
🔧 작업 내용
		1. 홈 화면 하단 네비게이션 매칭 버튼 클릭 시 /matches/ 페이지로 이동하도록 변경
		2. matches/views.py 수정
	•	매칭 요청 목록/완료된 매칭 목록 API 수정
	•	상대방 닉네임, 전공/학년 등 직렬화 데이터 반영
                 3. matches/urls.py 수정
	• 	기존 API URL 유지하면서 새로운 API 엔드포인트 추가
		4. matches/templates/matches/matches.html 수정
	•	상대방 닉네임 표시 로직 수정 (창업왕철수 → 실제 매칭 상대방 닉네임)
		5. matches/static/matches/js/matches.js 수정
	•	홈 화면에서 매칭 버튼 클릭 시 이동 기능 반영
	•	기존 alert 기능 제거
	•	매칭 페이지 탭 전환, 모달 열기/닫기 로직 개선
		6. matches/serializers.py 수정
	•	직렬화 시 상대방 정보 반환 로직 추가
                 7. 로그아웃안되는 오류 해결

⸻

🔍 확인 방법
	1.	홈 화면에서 하단 네비게이션의 🤝 매칭 버튼 클릭 시 /matches/ 페이지로 이동하는지 확인
	2.	매칭 페이지에서 대화 신청 탭에 매칭 요청 목록이 정상 출력되는지 확인
	3.	닉네임이 더미 값이 아닌 실제 매칭 상대방의 닉네임으로 표시되는지 확인
	4.	완료된 만남 탭에 완료된 매칭 목록이 정상 출력되는지 확인
	5.	모달(거절 사유, 리뷰 작성)이 정상적으로 열리고 닫히는지 확인
	6.  마이페이지에서 로그아웃 버튼클릭 혹은 users/logout/입력 후에 로그인페이지로 돌아가는지와 localstorage에 토큰들이 비어있는지 확인

⸻

📌 기타 참고 사항
	•	기존 api/ prefix를 유지하여 API URL 경로 변경 없이 동작하도록 구성
	•	추후 매칭 수락/거절 API와 채팅방 생성 로직 연동 필요
	•	매칭 데이터 더미 생성 후 Postman으로 API 응답 형식 테스트 완료
