### PR TITLE
fix: 대화 신청 오류 수정, 상세 페이지 성격 키워드 보이게 수정

### DIFF
--- a/apps/profiles/templates/profiles/profile_2.html
+++ b/apps/profiles/templates/profiles/profile_2.html
@@ -34,7 +34,7 @@
         </div>
         <div class="tag-container">
             {% for interest in interests %}
-            <div class="tag" data-label="{{ interest.name }}" data-id="{{ interest.id }}">#{{ interest.name }}</div>
+            <div class="tag" data-id="{{ interest.id }}" data-keyword="{{ interest.name }}">#{{ interest.name }}</div>
             {% endfor %}
         </div>
         <div class="comment">
@@ -101,14 +101,36 @@
           ? '좋아요! 이제 다음 단계로 넘어갈 수 있어요.'
           : '정확한 매칭을 위해 관심사 4개를 모두 선택해주세요.';
       }
+      // 5단계 스타일과 동일: 최대치 도달 시 나머지 비활성화/투명도 처리
+      tagNodes.forEach(node => {
+        const id = node.getAttribute('data-id');
+        const isSelected = selected.has(id);
+        if (count >= MAX_SELECT && !isSelected) {
+          node.classList.add('disabled');
+          node.style.pointerEvents = 'none';
+          node.style.opacity = '0.5';
+          node.style.color = '#64748b';
+        } else {
+          node.classList.remove('disabled');
+          node.style.pointerEvents = 'auto';
+          node.style.opacity = '1';
+          node.style.color = '';
+        }
+      });
       nextButton.disabled = (count !== MAX_SELECT);
     }
 
     function applySelectionStyles() {
       tagNodes.forEach(node => {
         const id = node.getAttribute('data-id');
-        if (selected.has(id)) node.classList.add('selected');
-        else node.classList.remove('selected');
+        const keyword = node.getAttribute('data-keyword');
+        if (selected.has(id)) {
+          node.classList.add('selected');
+          node.innerHTML = `✨ #${keyword}`;
+        } else {
+          node.classList.remove('selected');
+          node.innerHTML = `#${keyword}`;
+        }
       });
     }
 
@@ -136,6 +158,8 @@
         if (selected.has(id)) {
           selected.delete(id);
           node.classList.remove('selected');
+          const keyword = node.getAttribute('data-keyword');
+          node.innerHTML = `#${keyword}`;
         } else {
           if (selected.size >= MAX_SELECT) {
             // 최대 4개 제한 안내
@@ -144,6 +168,8 @@
           } else {
             selected.add(id);
             node.classList.add('selected');
+            const keyword = node.getAttribute('data-keyword');
+            node.innerHTML = `✨ #${keyword}`;
           }
         }
         updateCounterUI();

--- a/apps/profiles/templates/profiles/profile_detail.html
+++ b/apps/profiles/templates/profiles/profile_detail.html
@@ -251,7 +251,7 @@
                             <h5>성격 키워드</h5>
                             <div class="personality-tags">
                                 {% for keyword in personality_keywords %}
-                                <span class="personality-badge">#{{ keyword.keyword }}</span>
+                                <span class="personality-badge">#{{ keyword }}</span>
                                 {% empty %}
                                 <p>아직 성격 키워드가 등록되지 않았습니다.</p>
                                 {% endfor %}

--- a/apps/profiles/templates/profiles/profile_detail.html
+++ b/apps/profiles/templates/profiles/profile_detail.html
@@ -432,12 +432,12 @@
                 return;
             }
 
-            const toProfileId = window.TARGET_PROFILE_ID; // 상세 대상 프로필 ID
-            const payload = { reason, to_profile_id: toProfileId };
+            const receiverUserId = {{ profile.user.id }}; // 수신자(상대) User ID
+            const payload = { receiver: receiverUserId, request_message: reason };
 
             (async () => {
               try {
-                const res = await authFetch('/api/match-request/', {
+                const res = await authFetch('/matches/api/matches/', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify(payload)
@@ -449,7 +449,13 @@
                   document.getElementById('applicationReason').value = '';
                 } else {
                   const err = await res.json().catch(() => ({}));
-                  alert('신청 실패: ' + (err.error || JSON.stringify(err)));
+                  // DRF 에러 포맷 우선순위로 메시지 추출
+                  const msg = (err.non_field_errors && err.non_field_errors[0])
+                           || (err.receiver && err.receiver[0])
+                           || err.detail
+                           || err.error
+                           || JSON.stringify(err);
+                  alert('신청 실패: ' + msg);
                 }
               } catch (e) {
                 console.error(e);


### PR DESCRIPTION
# ✅ 제목  
[fix] 대화 신청 오류 수정 및 성격 키워드 표시

# 🔧 작업 내용  
- 대화 신청 API 연동 수정  
- 호출 경로를 `/matches/api/matches/`로 변경  
- 요청 페이로드를 `{ receiver: user_id, request_message: string }` 형식으로 수정  
- 에러 메시지 파싱 로직 보완(DRF 포맷 우선 추출)  
- 프로필 상세 성격 키워드 표시 수정  
- 템플릿에서 `#{{ keyword }}`로 렌더링되도록 수정  

# 🔍 확인 방법  
- 프로필 상세 페이지에서 “이 분과 대화해볼래요” 클릭 → 메시지 작성 → 신청하기  
- 성공 시: 알림 후 모달 닫힘  
- 실패 시: 구체적인 사유 노출(중복 신청, 본인 신청 등)  
- 성격 키워드  
  - 마이페이지에서 성격 키워드 3개 저장 후 상세 페이지에서 배지 형태로 노출되는지 확인  

