### PR TITLE
[fix] 액세스 토큰 만료시간 연장

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -228,3 +228,9 @@ STATICFILES_DIRS = [
 ]
 
 STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+from datetime import timedelta
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),  # 액세스 토큰 만료 시간: 30분으로 연장
+}


### PR DESCRIPTION
## ✅ 제목  
[fix] 액세스 토큰 만료시간 연장

---

## 🔧 작업 내용  
- 액세스 토큰 만료시간 연장(30분)

---

## 🔍 확인 방법  
- settings.py에서 확인 가능(timedelta)

---

## 📌 기타 참고 사항  

---
