### PR TITLE
[fix]: 마이페이지 자기소개 검증 및 UI/데이터 수정

### DIFF
--- a/apps/matches/templates/matches/browse.html
+++ b/apps/matches/templates/matches/browse.html
@@ -43,40 +43,64 @@
 </div><hr>
 
 <div class="recommends">
-    {# {% for match in matchings %} #}
-        <div class="recommend">
-            <div class="recommend-left">
-                <div class="circle">
-                    닉
+    {% if profiles %}
+        {% for profile in profiles %}
+            <div class="recommend">
+                <div class="recommend-left">
+                    <div class="circle">
+                        {{ profile.nickname|default:profile.user.username|first|upper }}
+                    </div>
+                </div>
+                <div class="recommend-right">
+                    <div class="content-top">
+                        <div class="information">
+                            <div class="nickname">
+                                {{ profile.nickname|default:profile.user.username }} ({{ profile.age|default:"?" }})
+                            </div>
+                            <div class="major">
+                                {% if profile.department %}
+                                    {{ profile.department.department_name }}
+                                    {% if profile.grade %}{{ profile.grade }}{% endif %}
+                                {% else %}
+                                    {% if profile.school %}{{ profile.school.school_name }}{% endif %}
+                                {% endif %}
+                                {% if profile.mbti %}• {{ profile.mbti }}{% endif %}
+                            </div>
+                        </div>
+                        <div class="rating">⭐ 4.5</div>
+                    </div>
+                    <div class="content-bottom">
+                        <div class="interest-comment">
+                            {% if profile.introduction %}
+                                {{ profile.introduction|truncatechars:100 }}
+                            {% else %}
+                                새로운 친구를 만나고 싶어요! 함께 대화하며 서로 배워가고 싶습니다.
+                            {% endif %}
+                        </div>
+                        <div class="tags">
+                            {% for profile_interest in profile.interests.all|slice:":4" %}
+                                <div class="small-tag">#{{ profile_interest.interest.name }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="detail-link">
+                            <a href="{% url 'profiles:profile-detail' profile.profile_id %}">자세히 보기</a>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <div class="recommend-right">
-                <div class="content-top">
-                    <div class="information">
-                        <div class="nickname">
-                            창업왕 철수 (22)
-                        </div>
-                        <div class="major">
-                            경영학과 3학년 • ENFP
-                        </div>
-                    </div>
-                    <div class="rating">⭐ 4.8</div>
-                </div>
-                <div class="content-bottom">
-                    <div class="interest-comment">스타트업에 관심이 많고, 창업 아이디어를 나누고 싶어요! 함께 성장할 수 있는 분과 가벼운 대화를 나누며 서로 배워가고 싶습니다.</div>
-                    <div class="tags">
-                        <div class="small-tag">#창업</div>
-                        <div class="small-tag">#마케팅</div>
-                        <div class="small-tag">#스타트업</div>
-                        <div class="small-tag">#투자</div>
-                    </div>
-                    <div class="detail-link">
-                        <a href="#">자세히 보기</a>
-                    </div>
+        {% endfor %}
+    {% else %}
+        <div class="no-profiles">
+            <div class="no-profiles-content">
+                <div class="no-profiles-icon">👥</div>
+                <div class="no-profiles-title">아직 프로필이 없어요</div>
+                <div class="no-profiles-description">
+                    다른 사용자들이 프로필을 완성하면 여기에 표시됩니다.<br>
+                    먼저 나의 프로필을 완성해보세요!
                 </div>
             </div>
         </div>
-    {# {% endfor %} #}
+    {% endif %}
 </div>
 
 <div class="modal-overlay" id="modal-overlay"></div>

--- a/apps/matches/views.py
+++ b/apps/matches/views.py
@@ -189,6 +189,21 @@ def matching_browse(request):
     interests = Interest.objects.all()
     universities = School.objects.prefetch_related('departments').all()
 
+    # 실제 프로필 데이터 가져오기 (완료된 프로필만)
+    from apps.profiles.models import Profile
+    profiles = Profile.objects.filter(
+        current_step='completed',
+        is_active=True
+    ).exclude(
+        user=request.user  # 본인 제외
+    ).select_related(
+        'user',
+        'school',
+        'department'
+    ).prefetch_related(
+        'interests__interest'
+    )[:10]  # 최대 10개만 표시
+
     # 직렬화하여 학과 포함한 JSON 생성
     universities_data = []
     for uni in universities:
@@ -205,5 +220,6 @@ def matching_browse(request):
         'interests': interests,
         'universities': universities,
         'universities_json': universities_data,  # 템플릿에서 JSON으로 사용
+        'profiles': profiles,  # 실제 프로필 데이터
     }
     return render(request, 'matches/browse.html', context)

--- a/apps/users/static/users/css/mypage.css
+++ b/apps/users/static/users/css/mypage.css
@@ -621,6 +621,20 @@ body {
     box-shadow: var(--shadow-lg);
 }
 
+.save-button:disabled {
+    background: linear-gradient(135deg, #9ca3af, #d1d5db);
+    color: #6b7280;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+    opacity: 0.6;
+}
+
+.save-button:disabled:hover {
+    transform: none;
+    box-shadow: none;
+}
+
 .cancel-button {
     flex: 1;
     background: var(--card-background);

--- a/apps/users/static/users/css/mypage.css
+++ b/apps/users/static/users/css/mypage.css
@@ -865,22 +865,3 @@ body {
     outline: none;
 }
 
-/* 다크 모드 대응 */
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background-color: #0f172a;
-        --card-background: #1e293b;
-        --border-color: #334155;
-        --text-primary: #f1f5f9;
-        --text-secondary: #94a3b8;
-        --text-muted: #64748b;
-    }
-    
-    .schedule-cell {
-        background-color: #334155;
-    }
-    
-    .schedule-cell:hover {
-        background-color: var(--primary-light);
-    }
-}

--- a/apps/users/static/users/css/mypage.css
+++ b/apps/users/static/users/css/mypage.css
@@ -1,43 +1,12 @@
 /* 마이페이지 스타일 */
 
-/* 기본 변수 */
+/* 기본 변수 - base.css 상속 */
+/* primary-color만 마이페이지 전용으로 오버라이드 */
 :root {
     --primary-color: #3b82f6;
-    --primary-light: #dbeafe;
-    --secondary-color: #6b7280;
-    --success-color: #10b981;
-    --error-color: #ef4444;
-    --background-color: #f8fafc;
-    --card-background: #ffffff;
-    --border-color: #e5e7eb;
-    --text-primary: #1f2937;
-    --text-secondary: #6b7280;
-    --text-muted: #9ca3af;
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-    --radius-sm: 0.375rem;
-    --radius-md: 0.5rem;
-    --radius-lg: 0.75rem;
-    --radius-xl: 1rem;
-    --radius-2xl: 1.5rem;
-    --radius-3xl: 2rem;
 }
 
-/* 전역 스타일 */
-* {
-    box-sizing: border-box;
-}
-
-body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background-color: var(--background-color);
-    color: var(--text-primary);
-    line-height: 1.6;
-    margin: 0;
-    padding: 0;
-}
-
+/* 전역 스타일 - base.css 상속 */
 .container {
     padding-bottom: 5rem;
     background-color: var(--background-color);
@@ -653,92 +622,106 @@ body {
     border-color: var(--text-secondary);
 }
 
-/* 반응형 디자인 */
-@media (max-width: 640px) {
+/* 반응형 디자인 - base.css 상속 */
+/* 태블릿 (768px 이상) */
+@media (min-width: 768px) {
     .main-content {
-        padding: 0.75rem;
-        gap: 1rem;
-        padding-bottom: 8rem; /* 모바일에서 더 많은 하단 여백 */
+        padding: 1.5rem;
+        gap: 1.5rem;
     }
     
     .section-card {
-        padding: 1rem;
-    }
-    
-    .profile-header-card {
         padding: 1.5rem;
     }
     
+    .profile-header-card {
+        padding: 2.5rem;
+    }
+    
     .profile-avatar {
-        width: 5rem;
-        height: 5rem;
+        width: 7rem;
+        height: 7rem;
     }
     
     .avatar-fallback {
-        font-size: 1.25rem;
+        font-size: 1.75rem;
     }
     
     .form-row {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr 1fr;
     }
     
     .schedule-header {
-        grid-template-columns: 3rem repeat(7, 1fr);
+        grid-template-columns: 4rem repeat(7, 1fr);
     }
     
     .schedule-row {
-        grid-template-columns: 3rem repeat(7, 1fr);
+        grid-template-columns: 4rem repeat(7, 1fr);
     }
     
     .time-cell {
-        font-size: 0.625rem;
-        padding: 0.375rem;
-    }
-    
-    .day-cell {
         font-size: 0.75rem;
         padding: 0.5rem;
     }
     
+    .day-cell {
+        font-size: 0.875rem;
+        padding: 0.75rem;
+    }
+    
     .schedule-grid {
-        max-height: 12rem;
+        max-height: 18rem;
     }
     
     .form-actions {
-        flex-direction: column;
-    }
-    
-    .header-content {
-        padding: 0 0.5rem;
-    }
-    
-    .header-left {
-        gap: 0.5rem;
+        flex-direction: row;
     }
     
     .section-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.75rem;
+        flex-direction: row;
+        align-items: center;
+        gap: 1rem;
     }
     
     .edit-button {
-        align-self: flex-end;
+        align-self: center;
     }
     
     .info-row {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.25rem;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.5rem;
     }
     
     .info-value {
-        word-break: break-word;
+        word-break: normal;
+        max-width: 60%;
     }
     
-    /* 모바일에서 상세 정보 섹션 여백 추가 */
     .section-card[data-section="advanced"] {
-        margin-bottom: 3rem;
+        margin-bottom: 2rem;
+    }
+}
+
+/* 데스크톱 (1024px 이상) */
+@media (min-width: 1024px) {
+    .main-content {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem;
+    }
+    
+    .profile-header-card {
+        padding: 3rem;
+    }
+    
+    .profile-avatar {
+        width: 8rem;
+        height: 8rem;
+    }
+    
+    .avatar-fallback {
+        font-size: 2rem;
     }
 }
 

--- a/apps/users/static/users/js/mypage.js
+++ b/apps/users/static/users/js/mypage.js
@@ -5,6 +5,38 @@ let scheduleData = Array(7).fill(null).map(() => Array(25).fill(false));
 
 // 페이지 로드 시 초기화
 document.addEventListener('DOMContentLoaded', function() {
+    // 자기소개 50자 카운터 즉시 반영
+    const introArea = document.getElementById('basic-introduction');
+    const countEl = document.getElementById('basic-intro-count');
+    const msgEl = document.getElementById('basic-intro-message');
+    if (introArea && countEl && msgEl) {
+        // 프로필 4단계와 동일한 50자 이상 로직 적용
+        const MIN_TEXT = 50;
+        
+        function updateTextCount() {
+            const length = introArea.value.length;
+            countEl.textContent = `${length}/${MIN_TEXT}자`;
+            msgEl.innerHTML = length >= MIN_TEXT ? '✅ 완성!' : '📝 조금 더 써주세요';
+        }
+        
+        function updateButtonState() {
+            const saveButton = document.querySelector('#basic-edit .save-button');
+            if (saveButton) {
+                const isTextareaLongEnough = introArea.value.length >= MIN_TEXT;
+                saveButton.disabled = !isTextareaLongEnough;
+            }
+        }
+        
+        // 이벤트 리스너 추가
+        introArea.addEventListener('input', () => { 
+            updateTextCount(); 
+            updateButtonState(); 
+        });
+        
+        // 초기 상태 설정
+        updateTextCount();
+        updateButtonState();
+    }
     console.log('마이페이지 로드됨');
     
     // 기존 스케줄 데이터 로드 (가장 먼저 실행)
@@ -92,6 +124,41 @@ function toggleEditSection(section) {
         if (section === 'basic') {
             // 기본 정보는 이미 HTML에서 value로 설정되어 있음
             console.log('기본 정보 편집 모드 활성화');
+            
+            // 자기소개 50자 검증 로직 재초기화
+            const introArea = document.getElementById('basic-introduction');
+            const countEl = document.getElementById('basic-intro-count');
+            const msgEl = document.getElementById('basic-intro-message');
+            if (introArea && countEl && msgEl) {
+                const MIN_TEXT = 50;
+                
+                function updateTextCount() {
+                    const length = introArea.value.length;
+                    countEl.textContent = `${length}/${MIN_TEXT}자`;
+                    msgEl.innerHTML = length >= MIN_TEXT ? '✅ 완성!' : '📝 조금 더 써주세요';
+                }
+                
+                function updateButtonState() {
+                    const saveButton = document.querySelector('#basic-edit .save-button');
+                    if (saveButton) {
+                        const isTextareaLongEnough = introArea.value.length >= MIN_TEXT;
+                        saveButton.disabled = !isTextareaLongEnough;
+                    }
+                }
+                
+                // 기존 이벤트 리스너 제거 후 다시 추가
+                introArea.removeEventListener('input', updateTextCount);
+                introArea.removeEventListener('input', updateButtonState);
+                
+                introArea.addEventListener('input', () => { 
+                    updateTextCount(); 
+                    updateButtonState(); 
+                });
+                
+                // 초기 상태 설정
+                updateTextCount();
+                updateButtonState();
+            }
         } else if (section === 'interests') {
             updateInterestCount();
         } else if (section === 'schedule') {
@@ -139,6 +206,25 @@ function saveSection(section) {
             gender: document.getElementById('basic-gender').value,
             introduction: document.getElementById('basic-introduction').value
         };
+        
+        // 50자 검증 및 UI 피드백 (프로필 4단계와 동일한 로직)
+        const intro = (data.introduction || '').trim();
+        const countEl = document.getElementById('basic-intro-count');
+        const msgEl = document.getElementById('basic-intro-message');
+        const MIN_TEXT = 50;
+        
+        if (countEl) countEl.textContent = `${intro.length}/${MIN_TEXT}자`;
+        if (msgEl) msgEl.innerHTML = intro.length >= MIN_TEXT ? '✅ 완성!' : '📝 조금 더 써주세요';
+        
+        if (intro.length < MIN_TEXT) {
+            alert('자기소개는 최소 50자 이상 작성해주세요.');
+            if (saveButton) {
+                saveButton.disabled = false;
+                saveButton.innerHTML = '<span>💾</span> 저장';
+            }
+            return;
+        }
+        
         url = '/profiles/update-basic/';
     } else if (section === 'interests') {
         const selectedInterests = getSelectedValues('#interests-edit', 'interests');

--- a/apps/users/templates/users/mypage.html
+++ b/apps/users/templates/users/mypage.html
@@ -104,8 +104,15 @@
                         </div>
                     </div>
                     <div class="form-group">
-            <label class="form-label">자기소개 *</label>
-            <textarea class="form-textarea" id="basic-introduction" required placeholder="자기소개를 작성해보세요">{{ user.profile.introduction }}</textarea>
+                        <label class="form-label">자기소개 *</label>
+                        <textarea class="form-textarea" id="basic-introduction" required placeholder="자기소개를 작성해보세요 (최소 50자 이상)">{{ user.profile.introduction }}</textarea>
+                        <div class="intro-meta" style="display:flex; justify-content: space-between; margin-top: 6px; font-size: 12px; color: #64748b;">
+                            <div id="basic-intro-count">0/50자</div>
+                            <span id="basic-intro-message">📝 조금 더 써주세요</span>
+                        </div>
+                        <div class="form-help-text" style="font-size: 11px; color: #94a3b8; margin-top: 4px;">
+                            💡 정확한 매칭을 위해 자기소개는 최소 50자 이상 작성해주세요
+                        </div>
                     </div>
                     <div class="form-actions">
             <button class="save-button" onclick="saveSection('basic')"><span>💾</span> 저장</button>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -72,34 +72,43 @@ body {
 대형 데스크톱: @media (min-width: 1280px)
 */
 
-/* 반응형 헬퍼 클래스 */
+/* 반응형 헬퍼 클래스 - 모바일 퍼스트 */
 .hidden-mobile {
-    display: block;
-}
-
-.hidden-desktop {
     display: none;
 }
 
-/* 모바일 (480px 이하) */
-@media (max-width: 480px) {
+.hidden-desktop {
+    display: block;
+}
+
+/* 태블릿 (768px 이상) */
+@media (min-width: 768px) {
     .container {
-        padding: 0 0.75rem;
+        max-width: 768px;
+        padding: 0 1.5rem;
     }
     
     .hidden-mobile {
-        display: none;
+        display: block;
     }
     
     .hidden-desktop {
-        display: block;
+        display: none;
     }
 }
 
-/* 태블릿 (768px 이하) */
-@media (max-width: 768px) {
+/* 데스크톱 (1024px 이상) */
+@media (min-width: 1024px) {
     .container {
-        padding: 0 0.75rem;
+        max-width: 1024px;
+        padding: 0 2rem;
+    }
+}
+
+/* 대형 데스크톱 (1280px 이상) */
+@media (min-width: 1280px) {
+    .container {
+        max-width: 1200px;
     }
 }
 
@@ -176,28 +185,45 @@ body {
     background: rgba(99, 102, 241, 0.05);
 }
 
-/* 모바일 최적화 (480px 이하) */
-@media (max-width: 480px) {
-    /* 하단 네비게이션 모바일 조정 */
+/* 태블릿 (768px 이상) */
+@media (min-width: 768px) {
     .bottom-nav {
-        padding: 0.75rem 0.5rem;
+        padding: 1rem 1.5rem;
     }
     
     .nav-item {
-        padding: 0.5rem 0.75rem;
-        min-width: 50px;
+        padding: 0.75rem 1rem;
+        min-width: 80px;
     }
     
     .nav-emoji {
-        font-size: 1rem;
+        font-size: 1.375rem;
     }
     
     .nav-label {
-        font-size: 0.625rem;
+        font-size: 0.875rem;
     }
     
     .main-content {
-        padding-bottom: 5.5rem; /* 모바일에서 더 넉넉한 여백 */
+        padding-bottom: 100px;
+    }
+}
+
+/* 데스크톱 (1024px 이상) */
+@media (min-width: 1024px) {
+    .bottom-nav {
+        padding: 1rem 2rem;
+    }
+    
+    .nav-container {
+        max-width: 800px;
+    }
+}
+
+/* 대형 데스크톱 (1280px 이상) */
+@media (min-width: 1280px) {
+    .nav-container {
+        max-width: 1000px;
     }
 }
 


### PR DESCRIPTION
## ✅ 제목  
[fix] 마이페이지 자기소개 검증 및 UI/데이터 수정

---

## 🔧 작업 내용  
- 마이페이지 프로필 편집 시 자기소개 50자 이상 입력 검증 로직 추가
- 탐색 페이지 실제 데이터 적용  
- 탐색 페이지 "창업왕 철수님" 데이터 제거 
- 다크 모드 기능 삭제  
- base.css 미디어쿼리를 모바일 퍼스트(min-width) 방식으로 수정 

---

## 🔍 확인 방법  
1. **마이페이지 자기소개 검증**
   - 프로필 편집에서 자기소개 입력 후 저장 시, 50자 미만이면 경고창 표시  
   - 50자 이상 입력 시 정상 저장  
2. **탐색 페이지 데이터**
   - 실제 데이터가 표시되는지 확인  
   - "창업왕 철수님" 항목이 제거되었는지 확인  
3. **다크 모드**
   - 다크 모드 관련 UI 및 기능이 제거되었는지 확인  
4. **모바일 퍼스트 스타일**
   - 모바일/태블릿/데스크톱 화면 크기에서 스타일이 정상 반응하는지 확인  

---

## 📌 기타 참고 사항  
- 모바일 퍼스트 변환 후 스타일 우선순위 충돌이 없는지 추가 테스트 필요  
- 추후 매칭 요청 기능 PR과 병합 시 CSS 충돌 여부 
