### PR TITLE
[fix] 모바일 자기소개 박스 벗어남 수정, 시간표 21시까지 확장 및 정렬 수정, 데스크탑 상세정보 하단 여백 추가  

### DIFF
--- a/apps/profiles/static/profiles/css/detail.css
+++ b/apps/profiles/static/profiles/css/detail.css
@@ -320,6 +320,8 @@ body {
     width: 100%;
     max-height: 80vh;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
 }
 
@@ -350,6 +352,8 @@ body {
 
 .modal-body {
     padding: 1.5rem;
+    flex: 1;
+    overflow-y: auto;
 }
 
 .application-textarea {
@@ -380,6 +384,9 @@ body {
     display: flex;
     gap: 0.75rem;
     justify-content: flex-end;
+    position: sticky;
+    bottom: 0;
+    background: white;
 }
 
 .cancel-button {

--- a/apps/profiles/static/profiles/js/profile-onboarding.js
+++ b/apps/profiles/static/profiles/js/profile-onboarding.js
@@ -76,6 +76,14 @@ const ProfileStep1 = {
       return;
     }
 
+    function checkAllSelected() {
+      const allSelected = universitySelect.value &&
+                          majorSelect.value &&
+                          gradeSelect.value &&
+                          ageSelect.value;
+      nextButton.disabled = !allSelected;
+    }
+
     // 학교 선택 시 학과 목록 업데이트 (인증 필요하므로 authFetch 사용)
     universitySelect.addEventListener('change', function () {
       const schoolName = this.value;
@@ -90,7 +98,8 @@ const ProfileStep1 = {
               option.textContent = major;
               majorSelect.appendChild(option);
             });
-            ProfileStep1.checkAllSelected();
+            // 선택 상태 갱신
+            checkAllSelected();
           })
           .catch(error => {
             console.error('학과 목록 불러오기 실패:', error);
@@ -98,14 +107,6 @@ const ProfileStep1 = {
           });
       }
     });
-
-    function checkAllSelected() {
-      const allSelected = universitySelect.value &&
-                          majorSelect.value &&
-                          gradeSelect.value &&
-                          ageSelect.value;
-      nextButton.disabled = !allSelected;
-    }
 
     // 각 셀렉트에 change 핸들러 (존재하는 요소만 바인딩)
     [universitySelect, majorSelect, gradeSelect, ageSelect]

--- a/apps/users/static/users/css/mypage.css
+++ b/apps/users/static/users/css/mypage.css
@@ -149,7 +149,7 @@
 
 /* 상세 정보 섹션 특별 스타일 */
 .section-card[data-section="advanced"] {
-    margin-bottom: 2rem; /* 상세 정보 섹션 하단 여백 추가 */
+    margin-bottom: 4rem;
 }
 
 .section-header {
@@ -229,10 +229,10 @@
     font-size: 0.875rem;
     color: var(--text-primary);
     font-weight: 500;
-    /* 긴 텍스트가 잘리지 않도록 */
     word-break: break-word;
     max-width: 60%;
     text-align: right;
+    line-height: 1.4;
 }
 
 .intro-text {
@@ -242,6 +242,9 @@
     padding: 0.75rem;
     border-radius: var(--radius-2xl);
     margin: 0.25rem 0 0 0;
+    word-break: break-all;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 .empty-text {
@@ -494,20 +497,22 @@
     background-color: var(--background-color);
     border-radius: var(--radius-xl);
     border: 1px solid var(--border-color);
+    -webkit-overflow-scrolling: touch; /* iOS 스크롤 개선 */
 }
 
 .schedule-header {
     display: grid;
-    grid-template-columns: 4rem repeat(7, 1fr);
-    gap: 0.25rem;
+    grid-template-columns: 3.5rem repeat(7, 1fr);
+    gap: 0.125rem;
     margin-bottom: 0.75rem;
+    min-width: 500px; /* 모바일 최소 너비 */
 }
 
 .day-cell {
     text-align: center;
-    font-size: 0.875rem;
+    font-size: 0.75rem;
     font-weight: 500;
-    padding: 0.75rem;
+    padding: 0.5rem;
     background-color: rgba(156, 163, 175, 0.1);
     border-radius: var(--radius-xl);
     color: var(--text-primary);
@@ -516,31 +521,37 @@
 .schedule-grid {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
-    max-height: 16rem;
+    gap: 0.125rem;
+    max-height: 14rem;
     overflow-y: auto;
     padding: 0.5rem;
     background-color: var(--card-background);
     border-radius: var(--radius-lg);
+    min-width: 500px; /* 모바일 최소 너비 */
 }
 
 .schedule-row {
     display: grid;
-    grid-template-columns: 4rem repeat(7, 1fr);
-    gap: 0.25rem;
+    grid-template-columns: 3.5rem repeat(7, 1fr);
+    gap: 0.125rem;
     align-items: center;
+    min-height: 2rem; /* 모바일 최소 높이 */
 }
 
 .time-cell {
-    font-size: 0.75rem;
+    font-size: 0.625rem;
     font-weight: 500;
     text-align: center;
-    padding: 0.5rem;
+    padding: 0.375rem;
     color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1.75rem; /* 모바일 최소 높이 */
 }
 
 .schedule-cell {
-    height: 2rem;
+    height: 1.75rem;
     border: 1px solid var(--border-color);
     border-radius: var(--radius-lg);
     background-color: var(--card-background);
@@ -549,6 +560,10 @@
     /* 텍스트 표시 방지 */
     font-size: 0;
     color: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1.75rem; /* 모바일 최소 높이 */
 }
 
 .schedule-cell:hover {
@@ -653,15 +668,20 @@
     
     .schedule-header {
         grid-template-columns: 4rem repeat(7, 1fr);
+        gap: 0.25rem;
+        min-width: 600px;
     }
     
     .schedule-row {
         grid-template-columns: 4rem repeat(7, 1fr);
+        gap: 0.25rem;
+        min-height: 2.5rem;
     }
     
     .time-cell {
         font-size: 0.75rem;
         padding: 0.5rem;
+        min-height: 2rem;
     }
     
     .day-cell {
@@ -671,6 +691,13 @@
     
     .schedule-grid {
         max-height: 18rem;
+        min-width: 600px;
+        gap: 0.25rem;
+    }
+    
+    .schedule-cell {
+        height: 2rem;
+        min-height: 2rem;
     }
     
     .form-actions {
@@ -722,6 +749,14 @@
     
     .avatar-fallback {
         font-size: 2rem;
+    }
+    
+    .info-value {
+        max-width: 70%;
+    }
+    
+    .section-card[data-section="advanced"] {
+        margin-bottom: 5rem;
     }
 }
 
@@ -830,7 +865,13 @@
 }
 
 .modal-button.logout-button:hover {
-    background: var(--primary-hover);
+    background: #dc2626; /* red-600 */
+    color: #ffffff;
+}
+
+/* 로그아웃 이모지는 항상 빨간색 유지 */
+.logout-emoji {
+    color: #ef4444; /* red-500 */
 }
 
 /* 접근성 개선 */

--- a/apps/users/static/users/js/mypage.js
+++ b/apps/users/static/users/js/mypage.js
@@ -1,7 +1,7 @@
 // 마이페이지 JavaScript
 
 // 전역 변수
-let scheduleData = Array(7).fill(null).map(() => Array(25).fill(false));
+let scheduleData = Array(7).fill(null).map(() => Array(24).fill(false));
 
 // 페이지 로드 시 초기화
 document.addEventListener('DOMContentLoaded', function() {
@@ -349,12 +349,14 @@ function initializeSchedule() {
     // 기존 내용 제거
     scheduleGrid.innerHTML = '';
     
-    // 시간대별로 행 생성 (9:00-21:00, 30분 단위, 총 25개 슬롯)
+    // 시간대별로 행 생성 (9:00-21:00, 30분 단위, 총 24개 슬롯)
     const timeSlots = [];
-    for (let hour = 9; hour <= 21; hour++) {
+    for (let hour = 9; hour <= 20; hour++) {
         timeSlots.push(`${hour}:00`);
         timeSlots.push(`${hour}:30`);
     }
+    // 21:00만 추가 (21:30 제외)
+    timeSlots.push('21:00');
     
     timeSlots.forEach((time, timeIndex) => {
         const row = document.createElement('div');
@@ -391,7 +393,7 @@ function loadExistingSchedule() {
     console.log('loadExistingSchedule 함수 호출됨');
     
     // scheduleData 초기화
-    scheduleData = Array(7).fill(null).map(() => Array(25).fill(false));
+    scheduleData = Array(7).fill(null).map(() => Array(24).fill(false));
     
     // Django 템플릿에서 전달받은 기존 스케줄 데이터를 scheduleData에 설정
     if (typeof existingScheduleData !== 'undefined' && existingScheduleData.length > 0) {
@@ -425,14 +427,14 @@ function loadExistingSchedule() {
                 const endHour = parseInt(endTime.split(':')[0]);
                 const endMinute = parseInt(endTime.split(':')[1]);
                 
-                // 30분 단위 인덱스 계산 (9:00부터 시작, 25개 슬롯)
+                // 30분 단위 인덱스 계산 (9:00부터 시작, 24개 슬롯)
                 const startIndex = (startHour - 9) * 2 + (startMinute >= 30 ? 1 : 0);
                 const endIndex = (endHour - 9) * 2 + (endMinute >= 30 ? 1 : 0);
                 
                 console.log('시간 인덱스:', { startIndex, endIndex });
                 
                 // 해당 시간 슬롯들을 true로 설정
-                for (let i = Math.max(0, startIndex); i < Math.min(25, endIndex); i++) {
+                for (let i = Math.max(0, startIndex); i < Math.min(24, endIndex); i++) {
                     scheduleData[dayIndex][i] = true;
                 }
             } else {


### PR DESCRIPTION
## ✅ 제목  
[fix] 모바일 자기소개 박스 벗어남 수정, 시간표 21시까지 확장 및 정렬 수정, 데스크탑 상세정보 하단 여백 추가  

---

## 🔧 작업 내용  
- 자기소개 입력 시 모바일 화면에서 박스 밖으로 벗어나는 부분 수정  
- 시간표를 21시까지 확장하고, 모바일에서 요일과 시간 정렬 깨지는 문제 수정  
- 데스크탑 화면에서 상세정보 하단 여백 추가 → 현재목표 섹션까지 정상적으로 보이도록 수정  

---

## 🔍 확인 방법  
- 모바일 환경에서 자기소개 입력 시 텍스트가 박스 안에 정상적으로 표시되는지 확인  
- 모바일 환경에서 시간표 요일과 시간이 올바르게 정렬되는지, 21시까지 표시되는지 확인  
- 데스크탑 환경에서 상세정보 하단에 여백이 추가되어 현재목표 섹션이 잘 보이는지 확인  

---

